### PR TITLE
Upper, lower, concat functions, and CASE_SENSITIVE_LIKE_OPERATOR flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<springframework-boot.version>2.3.9.RELEASE</springframework-boot.version>
 		<springdoc-openapi-ui.version>1.5.4</springdoc-openapi-ui.version>
 		<h2database-h2.version>1.4.200</h2database-h2.version>
-		<de.flapdoodle.embed.mongo.version>3.0.0</de.flapdoodle.embed.mongo.version>
+		<de.flapdoodle.embed.mongo.version>2.2.0</de.flapdoodle.embed.mongo.version>
 		<javafaker.version>1.0.2</javafaker.version>
 		<junit.version>5.7.1</junit.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/src/main/java/com/turkraft/springfilter/compiler/node/FunctionType.java
+++ b/src/main/java/com/turkraft/springfilter/compiler/node/FunctionType.java
@@ -8,9 +8,33 @@ import com.turkraft.springfilter.exception.InvalidQueryException;
 
 public enum FunctionType {
 
-  ABSOLUTE(Number.class), AVERAGE(Number.class), MIN(Number.class), MAX(Number.class), SUM(
-      Number.class), SIZE(Collection.class), LENGTH(
-          String.class), TRIM(String.class), CURRENTTIME, CURRENTDATE, CURRENTTIMESTAMP;
+  ABSOLUTE(Number.class),
+
+  AVERAGE(Number.class),
+
+  MIN(Number.class),
+
+  MAX(Number.class),
+
+  SUM(Number.class),
+
+  SIZE(Collection.class),
+
+  LENGTH(String.class),
+
+  TRIM(String.class),
+
+  UPPER(String.class),
+
+  LOWER(String.class),
+
+  CONCAT(String.class, String.class),
+
+  CURRENTTIME,
+
+  CURRENTDATE,
+
+  CURRENTTIMESTAMP;
 
   private final Class<?>[] argumentTypes;
 

--- a/src/main/java/com/turkraft/springfilter/generator/ExpressionGenerator.java
+++ b/src/main/java/com/turkraft/springfilter/generator/ExpressionGenerator.java
@@ -175,6 +175,16 @@ public class ExpressionGenerator implements Generator<Expression<?>> {
       case TRIM:
         return criteriaBuilder.trim((Expression<String>) getter.apply(0));
 
+      case UPPER:
+        return criteriaBuilder.upper((Expression<String>) getter.apply(0));
+
+      case LOWER:
+        return criteriaBuilder.lower((Expression<String>) getter.apply(0));
+
+      case CONCAT:
+        return criteriaBuilder.concat((Expression<String>) getter.apply(0),
+            (Expression<String>) getter.apply(1));
+
     }
 
     throw new InvalidQueryException("Unsupported function " + type.name().toLowerCase());

--- a/src/main/java/com/turkraft/springfilter/generator/ExpressionGenerator.java
+++ b/src/main/java/com/turkraft/springfilter/generator/ExpressionGenerator.java
@@ -248,14 +248,25 @@ public class ExpressionGenerator implements Generator<Expression<?>> {
             (Expression<? extends Comparable>) rightExpression);
 
       case LIKE: {
-        if (ExpressionGeneratorParameters.ENABLE_ASTERISK_WITH_LIKE_OPERATOR
-            && expression.getRight() instanceof Input) {
+        // TODO: factorize
+        if (ExpressionGeneratorParameters.CASE_SENSITIVE_LIKE_OPERATOR) {
+          if (ExpressionGeneratorParameters.ENABLE_ASTERISK_WITH_LIKE_OPERATOR
+              && expression.getRight() instanceof Input) {
+            return criteriaBuilder.like((Expression) leftExpression, ((Input) expression.getRight())
+                .getValue().getValueAs(String.class).toString().replace('*', '%'));
+          }
+          return criteriaBuilder.like((Expression) leftExpression,
+              (Expression<String>) rightExpression);
+        } else {
+          if (ExpressionGeneratorParameters.ENABLE_ASTERISK_WITH_LIKE_OPERATOR
+              && expression.getRight() instanceof Input) {
+            return criteriaBuilder.like(criteriaBuilder.upper((Expression) leftExpression),
+                ((Input) expression.getRight()).getValue().getValueAs(String.class).toString()
+                    .toUpperCase().replace('*', '%'));
+          }
           return criteriaBuilder.like(criteriaBuilder.upper((Expression) leftExpression),
-              ((Input) expression.getRight()).getValue().getValueAs(String.class).toString()
-                  .toUpperCase().replace('*', '%'));
+              criteriaBuilder.upper((Expression<String>) rightExpression));
         }
-        return criteriaBuilder.like(criteriaBuilder.upper((Expression) leftExpression),
-            criteriaBuilder.upper((Expression<String>) rightExpression));
       }
 
       default:

--- a/src/main/java/com/turkraft/springfilter/generator/ExpressionGeneratorParameters.java
+++ b/src/main/java/com/turkraft/springfilter/generator/ExpressionGeneratorParameters.java
@@ -11,11 +11,15 @@ public class ExpressionGeneratorParameters {
 
   public static boolean ENABLE_ASTERISK_WITH_LIKE_OPERATOR;
 
+  public static boolean CASE_SENSITIVE_LIKE_OPERATOR;
+
   static {
 
     FILTERING_AUTHORIZATION = null;
 
     ENABLE_ASTERISK_WITH_LIKE_OPERATOR = true;
+
+    CASE_SENSITIVE_LIKE_OPERATOR = false;
 
   }
 

--- a/src/test/java/com/turkraft/springfilter/mongodb/Config.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/Config.java
@@ -8,7 +8,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import com.mongodb.client.MongoClients;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
@@ -27,7 +28,7 @@ public class Config implements InitializingBean, DisposableBean {
     String ip = "localhost";
     int port = 27017;
 
-    MongodConfig mongodConfig = MongodConfig.builder().version(Version.Main.PRODUCTION)
+    IMongodConfig mongodConfig = new MongodConfigBuilder().version(Version.Main.PRODUCTION)
         .net(new Net(ip, port, Network.localhostIsIPv6())).build();
 
     MongodStarter starter = MongodStarter.getDefaultInstance();


### PR DESCRIPTION
Fixes #70

May fix #74 

`ExpressionGeneratorParameters.CASE_SENSITIVE_LIKE_OPERATOR` can be set to true in order to manually handle the `~` operator. A case insensitive search can then be done with `upper(name) ~ '%JOHN%'` if desired so.

In order to search over multiple string fields, something like that can be done: `concat(firstName, concat(' ', lastName)) ~ 'John%Smith'`. Adding the `+` operator might be a good alternative to the concat function.