### PR TITLE
Support for dates and other field types with MongoDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 	</licenses>
 	<properties>
 		<java.version>1.8</java.version>
+		<commons-lang3.version>3.12.0</commons-lang3.version>
 		<lombok.version>1.18.16</lombok.version>
 		<hibernate.version>5.4.27.Final</hibernate.version>
 		<springframework.version>5.2.12.RELEASE</springframework.version>
@@ -47,6 +48,11 @@
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 	</properties>
 	<dependencies>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${commons-lang3.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/com/turkraft/springfilter/boot/Filter.java
+++ b/src/main/java/com/turkraft/springfilter/boot/Filter.java
@@ -11,4 +11,6 @@ public @interface Filter {
 
   String parameterName() default "filter";
 
+  Class<?> entityClass() default Void.class;
+
 }

--- a/src/main/java/com/turkraft/springfilter/boot/SpecificationFilterArgumentResolver.java
+++ b/src/main/java/com/turkraft/springfilter/boot/SpecificationFilterArgumentResolver.java
@@ -30,9 +30,7 @@ public class SpecificationFilterArgumentResolver implements HandlerMethodArgumen
     Filter filter = methodParameter.getParameterAnnotation(Filter.class);
 
     return getSpecification(methodParameter.getGenericParameterType().getClass(),
-        !filter.parameterName().isEmpty()
-            ? nativeWebRequest.getParameterValues(filter.parameterName())
-            : null);
+        nativeWebRequest.getParameterValues(filter.parameterName()));
 
   }
 

--- a/src/main/java/com/turkraft/springfilter/boot/SpecificationFilterArgumentResolver.java
+++ b/src/main/java/com/turkraft/springfilter/boot/SpecificationFilterArgumentResolver.java
@@ -29,11 +29,6 @@ public class SpecificationFilterArgumentResolver implements HandlerMethodArgumen
 
     Filter filter = methodParameter.getParameterAnnotation(Filter.class);
 
-    if (filter == null) {
-      return getSpecification(methodParameter.getGenericParameterType().getClass(),
-          nativeWebRequest.getParameterValues("filter"));
-    }
-
     return getSpecification(methodParameter.getGenericParameterType().getClass(),
         !filter.parameterName().isEmpty()
             ? nativeWebRequest.getParameterValues(filter.parameterName())

--- a/src/main/java/com/turkraft/springfilter/boot/SpecificationFilterArgumentResolver.java
+++ b/src/main/java/com/turkraft/springfilter/boot/SpecificationFilterArgumentResolver.java
@@ -29,6 +29,11 @@ public class SpecificationFilterArgumentResolver implements HandlerMethodArgumen
 
     Filter filter = methodParameter.getParameterAnnotation(Filter.class);
 
+    if (!filter.entityClass().equals(Void.class)) {
+      throw new IllegalArgumentException(
+          "The entity class should not be provided, " + filter.entityClass() + " was given");
+    }
+
     return getSpecification(methodParameter.getGenericParameterType().getClass(),
         nativeWebRequest.getParameterValues(filter.parameterName()));
 

--- a/src/main/java/com/turkraft/springfilter/generator/BsonGenerator.java
+++ b/src/main/java/com/turkraft/springfilter/generator/BsonGenerator.java
@@ -19,10 +19,14 @@ import com.turkraft.springfilter.exception.InvalidQueryException;
 
 public class BsonGenerator implements Generator<Bson> {
 
-  private static final BsonGenerator INSTANCE = new BsonGenerator();
+  private Class<?> entityClass;
 
-  public static Bson run(IExpression expression) {
-    return INSTANCE.generate(expression);
+  public static Bson run(Class<?> entityClass, IExpression expression) {
+    return new BsonGenerator(entityClass).generate(expression);
+  }
+
+  public BsonGenerator(Class<?> entityClass) {
+    this.entityClass = entityClass;
   }
 
   @Override
@@ -53,7 +57,8 @@ public class BsonGenerator implements Generator<Bson> {
     }
 
     String key = ((Field) expression.getLeft()).getName();
-    Object input = ((Input) expression.getRight()).getValue().getValue();
+    Object input = ((Input) expression.getRight()).getValue()
+        .getValueAs(EntityFieldTypeResolver.resolve(key, entityClass));
 
     switch (expression.getComparator()) {
 

--- a/src/main/java/com/turkraft/springfilter/generator/EntityFieldTypeResolver.java
+++ b/src/main/java/com/turkraft/springfilter/generator/EntityFieldTypeResolver.java
@@ -1,0 +1,35 @@
+package com.turkraft.springfilter.generator;
+
+import static org.apache.commons.lang3.reflect.FieldUtils.getField;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.util.Collection;
+
+// source: https://github.com/RutledgePaulV/rest-query-engine
+
+public class EntityFieldTypeResolver {
+
+  public static Class<?> resolve(String path, Class<?> root) {
+    String[] splitField = path.split("\\.", 2);
+    if (splitField.length == 1) {
+      return normalize(getField(root, splitField[0], true));
+    } else {
+      return resolve(splitField[1], normalize(getField(root, splitField[0], true)));
+    }
+  }
+
+  private static Class<?> normalize(Field field) {
+    if (Collection.class.isAssignableFrom(field.getType())) {
+      return getFirstTypeParameterOf(field);
+    } else if (field.getType().isArray()) {
+      return field.getType().getComponentType();
+    } else {
+      return field.getType();
+    }
+  }
+
+  private static Class<?> getFirstTypeParameterOf(Field field) {
+    return (Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
+  }
+
+}

--- a/src/main/java/com/turkraft/springfilter/generator/EntityFieldTypeResolver.java
+++ b/src/main/java/com/turkraft/springfilter/generator/EntityFieldTypeResolver.java
@@ -7,6 +7,9 @@ import java.util.Collection;
 
 // source: https://github.com/RutledgePaulV/rest-query-engine
 
+// this class is only used by the BsonGenerator, and adds the lang3 dependency unfortunately
+// it should be possible to get rid of it and use reflection/LambdaMetafactory
+
 public class EntityFieldTypeResolver {
 
   public static Class<?> resolve(String path, Class<?> root) {

--- a/src/main/java/com/turkraft/springfilter/generator/EntityFieldTypeResolver.java
+++ b/src/main/java/com/turkraft/springfilter/generator/EntityFieldTypeResolver.java
@@ -1,6 +1,5 @@
 package com.turkraft.springfilter.generator;
 
-import static org.apache.commons.lang3.reflect.FieldUtils.getField;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
@@ -15,9 +14,9 @@ public class EntityFieldTypeResolver {
   public static Class<?> resolve(String path, Class<?> root) {
     String[] splitField = path.split("\\.", 2);
     if (splitField.length == 1) {
-      return normalize(getField(root, splitField[0], true));
+      return normalize(getField(root, splitField[0]));
     } else {
-      return resolve(splitField[1], normalize(getField(root, splitField[0], true)));
+      return resolve(splitField[1], normalize(getField(root, splitField[0])));
     }
   }
 
@@ -33,6 +32,15 @@ public class EntityFieldTypeResolver {
 
   private static Class<?> getFirstTypeParameterOf(Field field) {
     return (Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
+  }
+
+  public static Field getField(final Class<?> klass, final String fieldName) {
+    Field field = org.apache.commons.lang3.reflect.FieldUtils.getField(klass, fieldName, true);
+    if (field == null) {
+      throw new com.turkraft.springfilter.exception.InvalidQueryException(
+          "Could not find field '" + fieldName + "' in " + klass);
+    }
+    return field;
   }
 
 }

--- a/src/main/java/com/turkraft/springfilter/repository/DocumentExecutor.java
+++ b/src/main/java/com/turkraft/springfilter/repository/DocumentExecutor.java
@@ -17,8 +17,8 @@ import com.turkraft.springfilter.generator.BsonGeneratorUtils;
 public interface DocumentExecutor<T, I> {
 
   default Optional<T> findOne(@Nullable Document doc) {
-    return Optional.ofNullable(getMongoOperations().findOne(BsonGeneratorUtils.getQueryFromDocument(doc),
-        getMetadata().getJavaType()));
+    return Optional.ofNullable(getMongoOperations()
+        .findOne(BsonGeneratorUtils.getQueryFromDocument(doc), getMetadata().getJavaType()));
   }
 
   default List<T> findAll(@Nullable Document doc) {
@@ -27,8 +27,8 @@ public interface DocumentExecutor<T, I> {
   }
 
   default Page<T> findAll(@Nullable Document doc, Pageable pageable) {
-    return new PageImpl<>(getMongoOperations()
-        .find(BsonGeneratorUtils.getQueryFromDocument(doc).with(pageable), getMetadata().getJavaType()));
+    return new PageImpl<>(getMongoOperations().find(
+        BsonGeneratorUtils.getQueryFromDocument(doc).with(pageable), getMetadata().getJavaType()));
   }
 
   default List<T> findAll(@Nullable Document doc, Sort sort) {

--- a/src/test/java/com/turkraft/springfilter/mongodb/Application.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/Application.java
@@ -30,14 +30,15 @@ public class Application implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args) throws IOException {
     mongoTemplate.save(Car.builder().name("Audi").someDate(Date.from(Instant.now())).build());
-    mongoTemplate.save(Car.builder().name("Merco").someDate(Date.from(Instant.MIN)).build());
+    mongoTemplate.save(Car.builder().name("Merco")
+        .someDate(Date.from(Instant.now().minusSeconds(60 * 60 * 24))).build());
   }
 
   @Autowired
   private CarRepository carRepository;
 
   @GetMapping(value = "car")
-  public List<Car> getCars(@Filter Document filter) {
+  public List<Car> getCars(@Filter(entityClass = Car.class) Document filter) {
     return carRepository.findAll(filter);
   }
 

--- a/src/test/java/com/turkraft/springfilter/mongodb/Application.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/Application.java
@@ -1,6 +1,8 @@
 package com.turkraft.springfilter.mongodb;
 
 import java.io.IOException;
+import java.sql.Date;
+import java.time.Instant;
 import java.util.List;
 import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,8 +29,8 @@ public class Application implements ApplicationRunner {
 
   @Override
   public void run(ApplicationArguments args) throws IOException {
-    mongoTemplate.save(Car.builder().name("Audi").build());
-    mongoTemplate.save(Car.builder().name("Merco").build());
+    mongoTemplate.save(Car.builder().name("Audi").someDate(Date.from(Instant.now())).build());
+    mongoTemplate.save(Car.builder().name("Merco").someDate(Date.from(Instant.MIN)).build());
   }
 
   @Autowired

--- a/src/test/java/com/turkraft/springfilter/mongodb/Car.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/Car.java
@@ -20,6 +20,8 @@ public class Car {
 
   private String name;
 
+  private int someNumber;
+
   private Date someDate;
 
 }

--- a/src/test/java/com/turkraft/springfilter/mongodb/Car.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/Car.java
@@ -1,5 +1,6 @@
 package com.turkraft.springfilter.mongodb;
 
+import java.util.Date;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import lombok.AllArgsConstructor;
@@ -18,5 +19,7 @@ public class Car {
   private String id;
 
   private String name;
+
+  private Date someDate;
 
 }

--- a/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
@@ -23,7 +23,7 @@ import com.turkraft.springfilter.generator.BsonGenerator;
 class MongoDBTest {
 
   void queryTest(IExpression expression, Bson query) {
-    assertEquals(query, BsonGenerator.run(expression));
+    assertEquals(query, BsonGenerator.run(Car.class, expression));
   }
 
   @Test

--- a/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
@@ -8,11 +8,10 @@ import static com.turkraft.springfilter.FilterBuilder.in;
 import static com.turkraft.springfilter.FilterBuilder.lessThan;
 import static com.turkraft.springfilter.FilterBuilder.lessThanOrEqual;
 import static com.turkraft.springfilter.FilterBuilder.not;
+import static com.turkraft.springfilter.FilterBuilder.numbers;
 import static com.turkraft.springfilter.FilterBuilder.or;
 import static com.turkraft.springfilter.FilterBuilder.strings;
 import static org.junit.Assert.assertEquals;
-import java.time.Instant;
-import java.util.Date;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -30,60 +29,55 @@ class MongoDBTest {
 
   @Test
   void equalStringTest() throws Exception {
-    queryTest(equal("key", "value"), Filters.eq("key", "value"));
+    queryTest(equal("name", "value"), Filters.eq("name", "value"));
   }
 
   @Test
   void equalNumberTest() throws Exception {
-    queryTest(equal("key", 0), Filters.eq("key", 0));
+    queryTest(equal("someNumber", 0), Filters.eq("someNumber", 0));
   }
 
   @Test
   void greaterThanTest() throws Exception {
-    queryTest(greaterThan("key", 0), Filters.gt("key", 0));
+    queryTest(greaterThan("someNumber", 0), Filters.gt("someNumber", 0));
   }
 
   @Test
   void greaterThanOrEqualTest() throws Exception {
-    queryTest(greaterThanOrEqual("key", 0), Filters.gte("key", 0));
+    queryTest(greaterThanOrEqual("someNumber", 0), Filters.gte("someNumber", 0));
   }
 
   @Test
   void lessThanTest() throws Exception {
-    queryTest(lessThan("key", 0), Filters.lt("key", 0));
+    queryTest(lessThan("someNumber", 0), Filters.lt("someNumber", 0));
   }
 
   @Test
   void lessThanOrEqualTest() throws Exception {
-    queryTest(lessThanOrEqual("key", 0), Filters.lte("key", 0));
+    queryTest(lessThanOrEqual("someNumber", 0), Filters.lte("someNumber", 0));
   }
 
   @Test
   void andTest() throws Exception {
-    queryTest(and(equal("a", "b"), equal("c", "d")),
-        Filters.and(Filters.eq("a", "b"), Filters.eq("c", "d")));
+    queryTest(and(equal("name", "x"), equal("id", "y")),
+        Filters.and(Filters.eq("name", "x"), Filters.eq("id", "y")));
   }
 
   @Test
   void orTest() throws Exception {
-    queryTest(or(equal("a", "b"), equal("c", "d")),
-        Filters.or(Filters.eq("a", "b"), Filters.eq("c", "d")));
+    queryTest(or(equal("name", "x"), equal("id", "y")),
+        Filters.or(Filters.eq("name", "x"), Filters.eq("id", "y")));
   }
 
   @Test
   void notTest() throws Exception {
-    queryTest(not(equal("key", "value")), Filters.not(Filters.eq("key", "value")));
+    queryTest(not(equal("name", "value")), Filters.not(Filters.eq("name", "value")));
   }
 
   @Test
   void inTest() throws Exception {
-    queryTest(in("a", strings("a", "b", "c")), Filters.in("a", "a", "b", "c"));
-  }
-
-  @Test
-  void inputConversionTest() throws Exception {
-    Date date = Date.from(Instant.now());
-    queryTest(equal("key", date), Filters.eq("key", date));
+    queryTest(in("id", strings("x", "y", "z")), Filters.in("id", "x", "y", "z"));
+    queryTest(in("someNumber", numbers(1, 2, 3)), Filters.in("someNumber", 1, 2, 3));
   }
 
 }

--- a/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
@@ -1,4 +1,4 @@
-package com.turkraft.springfilter.jpa;
+package com.turkraft.springfilter.mongodb;
 
 import static com.turkraft.springfilter.FilterBuilder.and;
 import static com.turkraft.springfilter.FilterBuilder.equal;

--- a/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
@@ -11,6 +11,8 @@ import static com.turkraft.springfilter.FilterBuilder.not;
 import static com.turkraft.springfilter.FilterBuilder.or;
 import static com.turkraft.springfilter.FilterBuilder.strings;
 import static org.junit.Assert.assertEquals;
+import java.time.Instant;
+import java.util.Date;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -76,6 +78,12 @@ class MongoDBTest {
   @Test
   void inTest() throws Exception {
     queryTest(in("a", strings("a", "b", "c")), Filters.in("a", "a", "b", "c"));
+  }
+
+  @Test
+  void inputConversionTest() throws Exception {
+    Date date = Date.from(Instant.now());
+    queryTest(equal("key", date), Filters.eq("key", date));
   }
 
 }


### PR DESCRIPTION
See #62 

The entity class on which filtering is applied should to provided in the `@Filter` annotation, for example:
```java
@GetMapping(value = "car")
public List<Car> getCars(@Filter(entityClass = Car.class) Document filter) {
  return carRepository.findAll(filter);
}
```