### PR TITLE
Fixed bug on count when using invalid or last page + 1

### DIFF
--- a/src/main/java/com/turkraft/springfilter/repository/DocumentExecutor.java
+++ b/src/main/java/com/turkraft/springfilter/repository/DocumentExecutor.java
@@ -29,7 +29,7 @@ public interface DocumentExecutor<T, I> {
 
   default Page<T> findAll(@Nullable Document doc, Pageable pageable) {
     Query query = BsonGeneratorUtils.getQueryFromDocument(doc).with(pageable);
-    long count = getMongoOperations().count(query, getMetadata().getJavaType());
+    long count = count(doc);
     List<T> content = getMongoOperations().find(query, getMetadata().getJavaType());
     return new PageImpl<>(content, pageable, count);
   }


### PR DESCRIPTION
Hi @torshid,

Saw that you reverted my pr and the bug @marcopag90 created #220 
Sorry about that 😢

I split up the pr and modified it to better suite the package setup.

This one is only a bug fix to get correct TotalPages, when sending a page that is greater than the last page.
Becasue the PageImpl need to be sent the complete count from the query exluding Pageable from query.

See the same operation from spring-mongo implementation here
[SimpleMongoRepository](https://github.com/spring-projects/spring-data-mongodb/blob/f15fd2a4182fa34d68b280fcd5c2f150ec43455f/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/repository/support/SimpleMongoRepository.java#L199)

Best regards
Linus Nibell