### PR TITLE
Added support to override BsonFilterArgumentResolver to accept custom codecs

### DIFF
--- a/src/main/java/com/turkraft/springfilter/boot/BsonFilterArgumentResolver.java
+++ b/src/main/java/com/turkraft/springfilter/boot/BsonFilterArgumentResolver.java
@@ -1,6 +1,7 @@
 package com.turkraft.springfilter.boot;
 
 import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -18,6 +19,16 @@ import com.turkraft.springfilter.parser.generator.bson.BsonGeneratorUtils;
  */
 
 public class BsonFilterArgumentResolver implements HandlerMethodArgumentResolver {
+
+  public final CodecRegistry codecRegistry;
+
+  public BsonFilterArgumentResolver() {
+    this(BsonGeneratorParameters.CODEC_REGISTRY);
+  }
+
+  public BsonFilterArgumentResolver(CodecRegistry codecRegistry) {
+    this.codecRegistry = codecRegistry;
+  }
 
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
@@ -50,7 +61,7 @@ public class BsonFilterArgumentResolver implements HandlerMethodArgumentResolver
       return bson;
     }
 
-    return BsonGeneratorUtils.getDocumentFromBson(bson);
+    return BsonGeneratorUtils.getDocumentFromBson(bson, codecRegistry);
 
   }
 

--- a/src/main/java/com/turkraft/springfilter/boot/BsonFilterArgumentResolver.java
+++ b/src/main/java/com/turkraft/springfilter/boot/BsonFilterArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.turkraft.springfilter.boot;
 
+import com.turkraft.springfilter.parser.generator.bson.BsonGeneratorParameters;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;

--- a/src/main/java/com/turkraft/springfilter/parser/generator/bson/BsonGeneratorUtils.java
+++ b/src/main/java/com/turkraft/springfilter/parser/generator/bson/BsonGeneratorUtils.java
@@ -5,22 +5,32 @@ import org.bson.BsonDocumentReader;
 import org.bson.Document;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.lang.Nullable;
 
 public class BsonGeneratorUtils {
 
   private BsonGeneratorUtils() {}
 
   public static Document getDocumentFromBson(Bson bson) {
+    return getDocumentFromBson(bson, null);
+  }
+
+  public static Document getDocumentFromBson(Bson bson, @Nullable CodecRegistry codecRegistry) {
 
     if (bson == null) {
       return null;
     }
 
+    if (codecRegistry == null) {
+      codecRegistry = BsonGeneratorParameters.CODEC_REGISTRY;
+    }
+
     BsonDocument bsonDocument =
-        bson.toBsonDocument(BsonDocument.class, BsonGeneratorParameters.CODEC_REGISTRY);
+        bson.toBsonDocument(BsonDocument.class, codecRegistry);
     DocumentCodec codec = new DocumentCodec();
     DecoderContext decoderContext = DecoderContext.builder().build();
     return codec.decode(new BsonDocumentReader(bsonDocument), decoderContext);


### PR DESCRIPTION
Hi @torshid,

Saw that you reverted my pr and the bug @marcopag90 created https://github.com/turkraft/spring-filter/issues/220
Sorry about that 😢

I split up the pr and modified it to better suite the package setup.

This is a suggestion how to enable the support for custom codecs and UUID.
By design mongodb have 4 ways how to handle UUID and if not set correct when generate a Document it will trigger a exception.
To solve that problem it's required to send the codec that it setup for the mongo-client.

I suggest that BsonFilterArgumentResolver is open to be overridable, so it can be extended with a CodecBsonFilterArgumentResolver, like this.

```java
package com.nibell.springfilter.boot.resolver;

import org.bson.codecs.configuration.CodecRegistry;

public class CodecBsonFilterArgumentResolver extends BsonFilterArgumentResolver {

    public CustomDocumentFilterArgumentResolver(CodecRegistry codecRegistry) {
        super(codecRegistry);
    }
}
```

And in config it's is added like this, localy

```java
package com.nibell.springfilter.boot.config;

import com.nibell.springfilter.boot.resolver.CodecBsonFilterArgumentResolver;
import org.springframework.beans.factory.annotation.Autowired;
import org.springframework.context.annotation.Configuration;
import org.springframework.data.mongodb.CodecRegistryProvider;
import org.springframework.web.method.support.HandlerMethodArgumentResolver;
import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

import java.util.List;

@Configuration
public class CustomSpringFilterWebConfig implements WebMvcConfigurer {

    @Autowired
    CodecRegistryProvider codecRegistryProvider;

    @Override
    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
        argumentResolvers.add(new CodecBsonFilterArgumentResolver (codecRegistryProvider.getCodecRegistry());
    }
}
```

Best regards
Linus Nibell