### PR TITLE
Fixed bug on (is null/is not null) when using (and/or) with MongoDb

### DIFF
--- a/src/main/java/com/turkraft/springfilter/parser/generator/bson/BsonGenerator.java
+++ b/src/main/java/com/turkraft/springfilter/parser/generator/bson/BsonGenerator.java
@@ -3,7 +3,6 @@ package com.turkraft.springfilter.parser.generator.bson;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import org.bson.BsonNull;
 import org.bson.conversions.Bson;
 import org.springframework.data.annotation.Id;
 import com.mongodb.client.model.Filters;
@@ -74,10 +73,10 @@ public class BsonGenerator extends FilterBaseVisitor<Bson> {
     switch (op) {
 
       case IS_NULL:
-        return Filters.eq(fieldName, BsonNull.VALUE);
+        return Filters.not(Filters.exists(fieldName));
 
       case IS_NOT_NULL:
-        return Filters.ne(fieldName, BsonNull.VALUE);
+        return Filters.exists(fieldName);
 
       case IS_EMPTY:
         return Filters.size(fieldName, 0);

--- a/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
+++ b/src/test/java/com/turkraft/springfilter/mongodb/MongoDBTest.java
@@ -6,6 +6,8 @@ import static com.turkraft.springfilter.FilterBuilder.greaterThan;
 import static com.turkraft.springfilter.FilterBuilder.greaterThanOrEqual;
 import static com.turkraft.springfilter.FilterBuilder.in;
 import static com.turkraft.springfilter.FilterBuilder.inputs;
+import static com.turkraft.springfilter.FilterBuilder.isNotNull;
+import static com.turkraft.springfilter.FilterBuilder.isNull;
 import static com.turkraft.springfilter.FilterBuilder.lessThan;
 import static com.turkraft.springfilter.FilterBuilder.lessThanOrEqual;
 import static com.turkraft.springfilter.FilterBuilder.not;
@@ -57,9 +59,25 @@ class MongoDBTest {
   }
 
   @Test
+  void nullTest() throws Exception {
+    queryTest(isNull("id"), Filters.not(Filters.exists("id")));
+  }
+
+  @Test
+  void isNotNullTest() throws Exception {
+    queryTest(isNotNull("id"), Filters.exists("id"));
+  }
+
+  @Test
   void andTest() throws Exception {
     queryTest(and(equal("name", "x"), equal("id", "y")),
         Filters.and(Filters.eq("name", "x"), Filters.eq("id", "y")));
+  }
+
+  @Test
+  void andNullTest() throws Exception {
+    queryTest(and(equal("name", "x"), isNull("id")),
+        Filters.and(Filters.eq("name", "x"), Filters.not(Filters.exists("id"))));
   }
 
   @Test


### PR DESCRIPTION
Hi @torshid @marcopag90,

I found a bug when using (and/or) with (is null/is not null) on MongoDb
It works correctly when using (is null/is not null) by themselves.

Api input is
```
date < '2022-10-30T18:35:24.00Z' or date is null
```

Get the following query when combining it with and/or operators to mongodb
```
{
    "$or": [
        {
            "date": {
                "$lt": {
                    "$date": "2022-10-30T18:35:24Z"
                }
            }
        },
        {
            "date": null
        }
    ]
}
```

Should be 
```
{
    "$or": [
        {
            "date": {
                "$lt": {
                    "$date": "2022-10-30T18:35:24Z"
                }
            }
        },
        {
            "date": {
                "$exists": false
            }
        }
    ]
} 
```

Change to match (is empty/is not empty) because they don't have that problem.
It's a bug in BsonNull.VALUE implantation, what I can gather. 

//Nibell